### PR TITLE
Make `print_summary` by default as true

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 ## Pytorch Model Summary
+[![PyPI version fury.io](https://badge.fury.io/py/pytorch-model-summary.svg)](https://pypi.python.org/pypi/pytorch-model-summary/)
+[![Downloads](https://pepy.tech/badge/pytorch-model-summary)](https://pepy.tech/project/pytorch-model-summary)
+
 
 It is a Keras style model.summary() implementation for PyTorch
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Pytorch Model Summary
+## Pytorch Model Summary -- Keras style `model.summary()` for PyTorch
 [![PyPI version fury.io](https://badge.fury.io/py/pytorch-model-summary.svg)](https://pypi.python.org/pypi/pytorch-model-summary/)
 [![Downloads](https://pepy.tech/badge/pytorch-model-summary)](https://pepy.tech/project/pytorch-model-summary)
 

--- a/pytorch_model_summary/model_summary.py
+++ b/pytorch_model_summary/model_summary.py
@@ -100,9 +100,9 @@ def summary(model, *inputs, batch_size=-1, show_input=False, show_hierarchical=F
     def model_input_hook(module, input):
         summary['Input'] = OrderedDict()
         summary['Input']['input_shape'] = shapes(input)
-        summary['Input']['nb_params'] = 1
-        summary['Input']['nb_params_trainable'] = 1
-        summary['Input']['trainable'] = 1
+        summary['Input']['nb_params'] = -1
+        summary['Input']['nb_params_trainable'] = -1
+        summary['Input']['trainable'] = -1
         summary['Input']['parent_layers'] = module_summary.get(id(module)).get('parent_layers')
         summary['Input']["output_shape"] = ()
     hooks.append(model.register_forward_pre_hook(model_input_hook))
@@ -112,9 +112,9 @@ def summary(model, *inputs, batch_size=-1, show_input=False, show_hierarchical=F
     def model_output_hook(module, input, output):
         summary['Output'] = OrderedDict()
         summary['Output']['input_shape'] = ()
-        summary['Output']['nb_params'] = 1
-        summary['Output']['nb_params_trainable'] = 1
-        summary['Output']['trainable'] = 1
+        summary['Output']['nb_params'] = -1
+        summary['Output']['nb_params_trainable'] = -1
+        summary['Output']['trainable'] = -1
         summary['Output']['parent_layers'] = module_summary.get(id(module)).get('parent_layers')
         summary['Output']["output_shape"] = shapes(output)
 

--- a/pytorch_model_summary/model_summary.py
+++ b/pytorch_model_summary/model_summary.py
@@ -9,7 +9,7 @@ from pytorch_model_summary.hierarchical_summary import hierarchical_summary
 
 
 def summary(model, *inputs, batch_size=-1, show_input=False, show_hierarchical=False, 
-            print_summary=False, max_depth=1, show_parent_layers=False):
+            print_summary=True, max_depth=1, show_parent_layers=False):
 
     max_depth = max_depth if max_depth is not None else 9999
 
@@ -169,5 +169,5 @@ def summary(model, *inputs, batch_size=-1, show_input=False, show_hierarchical=F
     str_summary = '\n'.join(lines)
     if print_summary:
         print(str_summary)
-
-    return str_summary
+    else:
+        return str_summary


### PR DESCRIPTION
Hi,
I've been using this module since a month and my experience with it has been largely pleasant. Thank you for your contribution 😄 

One thing i observed was that i was always using `print_summary` as True, so i just feel, using True as default is more user friendly. In fact using False asserts the usage of needing a string instead of a printed report more than expecting a user to print it everytime...

Edit:
I added a few more edits to i/o. I think the changes might have been too aggressive in design change, but we can test it out more and try to break it... 