### PR TITLE
Submodule can be None and should be ignored by hierarchical_summary

### DIFF
--- a/pytorch_model_summary/hierarchical_summary.py
+++ b/pytorch_model_summary/hierarchical_summary.py
@@ -19,6 +19,8 @@ def hierarchical_summary(model, print_summary=False):
         child_lines = []
         total_params = 0
         for key, module in model._modules.items():
+            if module is None:
+                continue
             mod_str, num_params = repr(module)
             mod_str = _addindent(mod_str, 2)
             child_lines.append('(' + key + '): ' + mod_str)


### PR DESCRIPTION
My model has different run conditions, and in some a submodule is set to `None` after initial load and not accessed any further.  The `hierarchical_summary` function does not consider this possibility.  Checking for the condition that a submodule is `None` 100% resolves the issue.  Thanks!